### PR TITLE
feat: add linear svd notebook

### DIFF
--- a/src/NeuralGraph/notebooks/svd_fly_vis.ipynb
+++ b/src/NeuralGraph/notebooks/svd_fly_vis.ipynb
@@ -1,0 +1,870 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "24850553",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import torch\n",
+    "import torch.jit\n",
+    "import torch.nn as nn\n",
+    "from torch.utils.data import DataLoader, TensorDataset\n",
+    "import sklearn.decomposition\n",
+    "import sklearn.manifold\n",
+    "import tqdm\n",
+    "import matplotlib.pyplot as plt\n",
+    "import matplotlib as mpl\n",
+    "import polars as pl\n",
+    "from mpl_toolkits.axes_grid1 import ImageGrid\n",
+    "%matplotlib inline"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "34f2f4ef",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# sim_dir = \"/groups/saalfeld/home/allierc/Py/NeuralGraph/graphs_data/fly/fly_N9_54_1\"\n",
+    "# use local copy - faster\n",
+    "sim_dir = \"/mnt/localdata/fly_N9_54_1\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "92b44fd8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "x = np.load(f\"{sim_dir}/x_list_0.npy\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "befbbf92",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "_, num_cells, _ = x.shape\n",
+    "print(x.shape, x.dtype)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "abf57435",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "neuron_types = x[0, :, 6].astype(np.int32)\n",
+    "index_to_name = {0: 'Am', 1: 'C2', 2: 'C3', 3: 'CT1(Lo1)', 4: 'CT1(M10)', 5: 'L1', 6: 'L2',\n",
+    "    7: 'L3', 8: 'L4', 9: 'L5', 10: 'Lawf1', 11: 'Lawf2', 12: 'Mi1', 13: 'Mi10',\n",
+    "    14: 'Mi11', 15: 'Mi12', 16: 'Mi13', 17: 'Mi14', 18: 'Mi15', 19: 'Mi2',\n",
+    "    20: 'Mi3', 21: 'Mi4', 22: 'Mi9', 23: 'R1', 24: 'R2', 25: 'R3', 26: 'R4',\n",
+    "    27: 'R5', 28: 'R6', 29: 'R7', 30: 'R8', 31: 'T1', 32: 'T2', 33: 'T2a',\n",
+    "    34: 'T3', 35: 'T4a', 36: 'T4b', 37: 'T4c', 38: 'T4d', 39: 'T5a', 40: 'T5b',\n",
+    "    41: 'T5c', 42: 'T5d', 43: 'Tm1', 44: 'Tm16', 45: 'Tm2', 46: 'Tm20', 47: 'Tm28',\n",
+    "    48: 'Tm3', 49: 'Tm30', 50: 'Tm4', 51: 'Tm5Y', 52: 'Tm5a', 53: 'Tm5b',\n",
+    "    54: 'Tm5c', 55: 'Tm9', 56: 'TmY10', 57: 'TmY13', 58: 'TmY14', 59: 'TmY15',\n",
+    "    60: 'TmY18', 61: 'TmY3', 62: 'TmY4', 63: 'TmY5a', 64: 'TmY9'\n",
+    "}\n",
+    "neuron_type_name = [\n",
+    "    \"Am\", \"C2\", \"C3\", \"CT1(Lo1)\", \"CT1(M10)\", \n",
+    "    \"L1\", \"L2\", \"L3\", \"L4\", \"L5\", \"Lawf1\", \"Lawf2\", \n",
+    "    \"Mi1\", \"Mi10\", \"Mi11\", \"Mi12\", \"Mi13\", \"Mi14\", \"Mi15\", \"Mi2\", \"Mi3\", \"Mi4\", \"Mi9\", \n",
+    "    \"R1\", \"R2\", \"R3\", \"R4\", \"R5\", \"R6\", \"R7\", \"R8\", \n",
+    "    \"T1\", \"T2\", \"T2a\", \"T3\", \"T4a\", \"T4b\", \"T4c\", \"T4d\", \"T5a\", \"T5b\", \"T5c\", \"T5d\", \n",
+    "    \"Tm1\", \"Tm16\", \"Tm2\", \"Tm20\", \"Tm28\", \"Tm3\", \"Tm30\", \"Tm4\", \"Tm5Y\", \n",
+    "    \"Tm5a\", \"Tm5b\", \"Tm5c\", \"Tm9\", \"TmY10\", \"TmY13\", \"TmY14\", \n",
+    "    \"TmY15\", \"TmY18\", \"TmY3\", \"TmY4\", \"TmY5a\", \"TmY9\"\n",
+    "]\n",
+    "neuron_type_index = {t: i for i, t in enumerate(neuron_type_name)}\n",
+    "\n",
+    "def compute_ixs_per_type(neuron_types):\n",
+    "    \"\"\"Compute indices corresponding to each neuron type.\"\"\"\n",
+    "    order = np.argsort(neuron_types)\n",
+    "    uniq_types, start_index = np.unique(neuron_types[order], return_index=True)\n",
+    "    num_neuron_types = len(uniq_types)\n",
+    "    assert (uniq_types == np.arange(num_neuron_types)).all(), \"breaks assumptions\"\n",
+    "    breaks = np.zeros(len(uniq_types)+1, dtype=np.int64)\n",
+    "    breaks[:-1] = start_index\n",
+    "    breaks[-1] = len(neuron_types)\n",
+    "    return [\n",
+    "        order[breaks[i]:breaks[i+1]] for i in range(num_neuron_types)\n",
+    "    ]\n",
+    "neuron_ixs_by_type = compute_ixs_per_type(neuron_types)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5ee79330",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "BURNIN_OFFSET = 100\n",
+    "OBS_TIME_STEPS = 20\n",
+    "\n",
+    "obs_ca = x[BURNIN_OFFSET::OBS_TIME_STEPS, :, 7].copy()\n",
+    "train_start = 0\n",
+    "validation_start = 3000\n",
+    "test_start = 3500\n",
+    "\n",
+    "train_mat = obs_ca[train_start:validation_start]\n",
+    "val_mat = obs_ca[validation_start:test_start]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ccd6c023",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# load some simulation network params\n",
+    "\n",
+    "wt = torch.load(f\"{sim_dir}/weights.pt\")\n",
+    "edge_index = torch.load(f\"{sim_dir}/edge_index.pt\")\n",
+    "voltage_rest = torch.load(f\"{sim_dir}/V_i_rest.pt\")\n",
+    "taus = torch.load(f\"{sim_dir}/taus.pt\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5271d9c5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "edge_index.shape, wt.shape"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "823ad64e",
+   "metadata": {},
+   "source": [
+    "## aside: spectral embedding of graph - see hexagonal structure"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d4fa4ab3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from scipy import sparse\n",
+    "from scipy.sparse.linalg import eigsh\n",
+    "\n",
+    "def spectral_embed(E, N, edim):\n",
+    "    \"\"\"\n",
+    "    Perform a 2D spectral embedding of a directed graph.\n",
+    "\n",
+    "    Parameters\n",
+    "    ----------\n",
+    "    E : np.ndarray\n",
+    "        2×M array of edges, where E[0, i] is the source and E[1, i] is the target.\n",
+    "        Nodes are labeled 0,…,N-1.\n",
+    "    N : int\n",
+    "        Total number of nodes.\n",
+    "\n",
+    "    Returns\n",
+    "    -------\n",
+    "    coords : np.ndarray of shape (N, 2)\n",
+    "        The 2D spectral embedding coordinates for each node (rows correspond to nodes).\n",
+    "    \"\"\"\n",
+    "    # --- 1. Build sparse adjacency matrix ---\n",
+    "    src, dst = E\n",
+    "    data = np.ones(len(src), dtype=float)\n",
+    "    A = sparse.coo_matrix((data, (src, dst)), shape=(N, N))\n",
+    "\n",
+    "    # --- 2. Make adjacency symmetric (convert to undirected for Laplacian) ---\n",
+    "    A = ((A + A.T) > 0).astype(float)\n",
+    "\n",
+    "    # --- 3. Compute normalized Laplacian L = I - D^{-1/2} A D^{-1/2} ---\n",
+    "    deg = np.array(A.sum(axis=1)).flatten()\n",
+    "    D_inv_sqrt = sparse.diags(1.0 / np.sqrt(np.maximum(deg, 1e-12)))\n",
+    "    L = sparse.eye(N) - D_inv_sqrt @ A @ D_inv_sqrt\n",
+    "\n",
+    "    # --- 4. Compute 2nd and 3rd smallest eigenvectors (skip trivial one) ---\n",
+    "    vals, vecs = eigsh(L, k=edim+1, which='SM')\n",
+    "    coords = vecs[:, 1:edim+1] \n",
+    "\n",
+    "    return coords\n",
+    "\n",
+    "\n",
+    "def spectral_embed_2d_weighted(E, W, N):\n",
+    "    \"\"\"\n",
+    "    Spectral embedding of a possibly signed, weighted directed graph.\n",
+    "    Converts to an undirected signed graph for embedding.\n",
+    "\n",
+    "    Parameters\n",
+    "    ----------\n",
+    "    E : np.ndarray, shape (2, M)\n",
+    "        Edge endpoints (source, target).\n",
+    "    W : np.ndarray, shape (M,)\n",
+    "        Edge weights (can be positive or negative).\n",
+    "    N : int\n",
+    "        Number of nodes (0..N-1).\n",
+    "\n",
+    "    Returns\n",
+    "    -------\n",
+    "    coords : np.ndarray, shape (N, 2)\n",
+    "        2D spectral embedding coordinates for each node.\n",
+    "    \"\"\"\n",
+    "    src, dst = E\n",
+    "\n",
+    "    # --- 1. Build sparse weighted adjacency matrix ---\n",
+    "    A = sparse.coo_matrix((W, (src, dst)), shape=(N, N))\n",
+    "    # Symmetrize (take average to preserve sign symmetry)\n",
+    "    A = 0.5 * (A + A.T)\n",
+    "\n",
+    "    # --- 2. Degree matrix (based on absolute weights to stay PSD) ---\n",
+    "    deg = np.array(np.abs(A).sum(axis=1)).flatten()\n",
+    "    D_inv_sqrt = sparse.diags(1.0 / np.sqrt(np.maximum(deg, 1e-12)))\n",
+    "\n",
+    "    # --- 3. Normalized signed Laplacian ---\n",
+    "    L = sparse.eye(N) - D_inv_sqrt @ A @ D_inv_sqrt\n",
+    "\n",
+    "    # --- 4. Compute smallest nontrivial eigenvectors ---\n",
+    "    vals, vecs = eigsh(L, k=3, which='SM')\n",
+    "    coords = vecs[:, 1:3]  # skip trivial eigenvector\n",
+    "\n",
+    "    return coords\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e3e1e30c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "eembed = spectral_embed(edge_index.cpu().numpy(), voltage_rest.shape[0], 10)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0b1da53a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "plt.scatter(eembed[:, 0], eembed[:, 1], alpha=0.1, marker=\".\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "81a9ac78",
+   "metadata": {},
+   "source": [
+    "## Find the optimal SVD dimension"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a8039759",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ndims = np.array([8, 16, 32, 64, 128])\n",
+    "\n",
+    "recon_train = np.zeros((len(ndims), train_mat.shape[0], train_mat.shape[1]))\n",
+    "recon_val = np.zeros((len(ndims), val_mat.shape[0], val_mat.shape[1]))\n",
+    "\n",
+    "svd = sklearn.decomposition.TruncatedSVD(n_components=ndims.max(), random_state = 321)\n",
+    "proj = svd.fit_transform(train_mat)\n",
+    "proj_val = svd.transform(val_mat)\n",
+    "for i, n in enumerate(ndims):\n",
+    "    recon_train[i, :, :] = np.matmul(proj[:, :n], svd.components_[:n, :])\n",
+    "    recon_val[i, :, :] = np.matmul(proj_val[:, :n], svd.components_[:n, :])\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f83c54d8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "delta_train = recon_train - train_mat[np.newaxis, :, :]\n",
+    "delta_val = recon_val - val_mat[np.newaxis, :, :]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b5eca758",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Compute variance along the time dimension\n",
+    "# We are most interested in learning about the dynamics per neuron\n",
+    "# So we focus on this dimension rather than along neuron space\n",
+    "\n",
+    "var_train = np.var(train_mat, axis=0)\n",
+    "var_train_unexpl = np.var(delta_train, axis=1)\n",
+    "r2_train = 1 - var_train_unexpl / var_train\n",
+    "var_val = np.var(val_mat, axis=0)\n",
+    "var_val_unexpl = np.var(delta_val, axis=1)\n",
+    "r2_val = 1 - var_val_unexpl/var_val"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "84d0a855",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "den, edges = np.histogram(var_train, bins=15)\n",
+    "for i, n in enumerate(ndims):\n",
+    "    num, _ = np.histogram(var_train, bins=edges, weights=(r2_train[i] < 0).astype(np.float32))\n",
+    "    plt.plot(edges[1:], num/den, label=f\"L={n}\")\n",
+    "plt.legend()\n",
+    "plt.ylabel(\"Fraction R2 < 0\")\n",
+    "plt.xlabel(\"Variance of neuron time trace\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "27377f05",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "den, edges = np.histogram(var_train, bins=15)\n",
+    "for i, n in enumerate(ndims):\n",
+    "    num, _ = np.histogram(var_train, bins=edges, weights=r2_train[i])\n",
+    "    plt.plot(edges[1:], num/den, label=f\"L={n}\")\n",
+    "plt.legend()\n",
+    "plt.ylabel(\"Mean R2\")\n",
+    "plt.xlabel(\"Variance of neuron time trace\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "17f33f6e",
+   "metadata": {},
+   "source": [
+    "## Fix latent dimension=256 and proceed"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "27c9a5cf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "L = 256\n",
+    "svd = sklearn.decomposition.TruncatedSVD(n_components=L)\n",
+    "svd.fit(train_mat)\n",
+    "\n",
+    "# import scipy.sparse.linalg\n",
+    "# U, S, VT = scipy.sparse.linalg.svds(train_mat, k=64) "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a410a6df",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "\n",
+    "proj = svd.transform(val_mat)\n",
+    "recon = np.dot(proj, svd.components_)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ccb2c8a0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# tsne = sklearn.manifold.TSNE()\n",
+    "# tsne.fit(svd.components_.T)\n",
+    "# df = pl.DataFrame({\n",
+    "#     \"type\": neuron_types,\n",
+    "#     \"svd1\": svd.components_[0],\n",
+    "#     \"svd2\": svd.components_[1],\n",
+    "#     \"t1\": tsne.embedding_[:, 0],\n",
+    "#     \"t2\": tsne.embedding_[:, 1],\n",
+    "# })\n",
+    "# for i, piece in df.group_by(\"type\"):\n",
+    "#     plt.scatter(piece[\"t1\"], piece[\"t2\"], marker=\".\", alpha=0.5)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6bdfaa22",
+   "metadata": {},
+   "source": [
+    "### analyze how well we can reconstruct"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d29e8ca4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# assess how good the reconstruction is across neurons (on validation data)\n",
+    "\n",
+    "delta = recon - val_mat\n",
+    "# noise per time point in the reconstructing from the latent space\n",
+    "err_t = delta.std(axis=1)\n",
+    "# signal variation\n",
+    "sigma_t = val_mat.std(axis=1)\n",
+    "plt.scatter(sigma_t, err_t, marker=\".\", alpha=0.5)\n",
+    "plt.xlabel(\"Sigma across neurons\")\n",
+    "plt.ylabel(\"Reconstruction sigma\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f980189c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Errors are gaussian\n",
+    "for i in np.random.randint(val_mat.shape[1], size=5):\n",
+    "    s = np.std(val_mat[:, i])\n",
+    "    plt.hist(delta[:, i], histtype=\"step\", label=f\"neuron {i} (sigma={s:.2f})\")\n",
+    "plt.legend(bbox_to_anchor=(1,1))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0343382a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for i in np.random.randint(val_mat.shape[0], size=5):\n",
+    "    s = np.std(val_mat[i])\n",
+    "    plt.hist(delta[i], histtype=\"step\", label=f\"time {i} (sigma={s:.2f})\")\n",
+    "plt.legend(bbox_to_anchor=(1,1))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "df06fb1d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# How well do we capture the variation over time using the reconstruction\n",
+    "\n",
+    "# error sigma per neuron\n",
+    "err_n = delta.std(axis=0)\n",
+    "# signal variation\n",
+    "sigma_n = train_mat.std(axis=0)\n",
+    "plt.scatter(sigma_n, err_n, marker=\".\", alpha=0.2)\n",
+    "plt.xlabel(\"Sigma across time\")\n",
+    "plt.ylabel(\"Reconstruction sigma\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c87a7e94",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.figure(figsize=(16, 6))\n",
+    "for ix in np.sort(np.random.randint(val_mat.shape[1], size=1)):\n",
+    "    p = plt.plot(val_mat[:, ix], label=f\"Neuron {ix} original\")\n",
+    "    plt.plot(recon[:, ix], c=p[-1].get_color(), ls=\"\", marker=\".\", label=f\"Neuron {ix} recon\")\n",
+    "plt.xlabel(\"time\")\n",
+    "plt.legend(bbox_to_anchor=(1,1))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3bcd5f5f",
+   "metadata": {},
+   "source": [
+    "## learn the latent space update (linear)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b9c9dab3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "device=torch.device(\"cuda\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2a9ea351",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "@torch.jit.script\n",
+    "def loss_fn(evolve_mat, train_proj):\n",
+    "    nmin = 1\n",
+    "    nmax = 6\n",
+    "    loss = torch.as_tensor(0.0, device=torch.device(\"cuda\"))\n",
+    "    for i in range(nmin, nmax):\n",
+    "        emat = torch.matrix_power(evolve_mat, i)\n",
+    "        loss += torch.pow(torch.linalg.matmul(train_proj[:-i, :], emat) - train_proj[i:], 2).mean()\n",
+    "    return loss\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6da9f360",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "# matrix initialized to 1+epsilon\n",
+    "init_mat = (torch.eye(L) + (torch.rand((L, L)) - 0.5) / 3.).to(device)\n",
+    "evolve_mat = torch.nn.Parameter(init_mat)\n",
+    "\n",
+    "train_proj = torch.tensor(svd.transform(train_mat), device=device)\n",
+    "optimizer = torch.optim.Adam([evolve_mat], lr=1e-2)\n",
+    "    \n",
+    "# train_loop(evolve_mat, train_proj, optimizer)\n",
+    "loop = tqdm.trange(10_000)\n",
+    "for t in loop:\n",
+    "    loss = loss_fn(evolve_mat, train_proj)\n",
+    "    if t % 10 == 0:\n",
+    "        loop.set_postfix(loss=loss.item())\n",
+    "    loss.backward()\n",
+    "    optimizer.step()\n",
+    "    optimizer.zero_grad()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f5c8f19c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "learned_mat = evolve_mat.detach().cpu().numpy()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "690d1178",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.imshow(learned_mat, vmax=1, vmin=0.1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1d2d4cf5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# rng = np.random.default_rng(seed=321)\n",
+    "# t0s = rng.integers(0, train_mat.shape[0]-30, size=5)\n",
+    "\n",
+    "T = 30\n",
+    "t0 = 1000\n",
+    "x0 = train_mat[t0:t0+1, :]\n",
+    "p0 = svd.transform(x0)\n",
+    "\n",
+    "results = [p0]\n",
+    "for t in range(T):\n",
+    "    x1 = np.matmul(results[-1], learned_mat)\n",
+    "    results.append(x1)\n",
+    "pred_trace = np.stack([np.matmul(r, svd.components_) for r in results], axis=0)\n",
+    "act_trace = train_mat[t0:t0+T+1]\n",
+    "recon_each = svd.inverse_transform(svd.transform(train_mat[t0:t0+T+1, :]))\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ed4017e6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot_neuron_types = np.sort(np.random.choice(neuron_type_name, 8))\n",
+    "# ['R1', 'R7', 'C2', 'Mi11', 'Tm1', 'Tm4', 'Tm30'] \n",
+    "\n",
+    "_, ax = plt.subplots(len(plot_neuron_types), 1, figsize=(8, 12), sharex=True)\n",
+    "tvals = np.arange(t0, t0+T+1)\n",
+    "rng = np.random.default_rng(seed=123)\n",
+    "picks = [rng.choice(nixs) for nixs in neuron_ixs_by_type]\n",
+    "\n",
+    "for i, ptype in enumerate(plot_neuron_types):\n",
+    "    nix = picks[neuron_type_index[ptype]]\n",
+    "    true_trace = train_mat[t0:t0+T+1, nix]\n",
+    "    ax[i].plot(tvals, true_trace)\n",
+    "    ax[i].set_ylim(true_trace.min()*0.8, true_trace.max()*1.2)\n",
+    "    # time evolve\n",
+    "    ax[i].plot(tvals, pred_trace[:, 0, nix], color=p[-1].get_color(), ls=\"dotted\", label=\"learn linear evolver\")\n",
+    "\n",
+    "    # reconstruct each point using SVD\n",
+    "    ax[i].plot(tvals, recon_each[:, nix], color=p[-1].get_color(), ls=\"dashed\", label=\"reconstruct each time point\")\n",
+    "    ax[i].set_ylabel(ptype)\n",
+    "\n",
+    "plt.subplots_adjust(hspace=0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "53c36754",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nix = np.random.randint(0, train_mat.shape[1])\n",
+    "print(f\"{nix=}\")\n",
+    "plt.figure(figsize=(16,6))\n",
+    "\n",
+    "\n",
+    "\n",
+    "# actual trace\n",
+    "trace = train_mat[t0:t0+T+1, nix]\n",
+    "p = plt.plot(tvals, trace, label=\"actual trace\")\n",
+    "\n",
+    "# time evolve\n",
+    "plt.plot(tvals, pred_trace[:, 0, nix], color=p[-1].get_color(), ls=\"dotted\", label=\"learn linear evolver\")\n",
+    "\n",
+    "# reconstruct each point using SVD\n",
+    "plt.plot(tvals, recon_each[:, nix], color=p[-1].get_color(), ls=\"dashed\", label=\"reconstruct each time point\")\n",
+    "    \n",
+    "plt.axvline(t0+10, color=\"k\", ls=\"dotted\")\n",
+    "plt.xticks(tvals)\n",
+    "\n",
+    "plt.xlabel(\"Time\")\n",
+    "plt.ylabel(\"Ca activity\")\n",
+    "plt.legend()\n",
+    "plt.title(f\"Neuron trace {nix=}\")\n",
+    "pass"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "711c1836",
+   "metadata": {},
+   "source": [
+    "## OK maybe we need a non-linear update"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "95e16988",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "device=torch.device(\"cuda\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "73b18006",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class MLP(torch.jit.ScriptModule):\n",
+    "    def __init__(self, num_latent_dims, num_hidden_units, num_hidden_layers):\n",
+    "        super().__init__()\n",
+    "        self.layers = torch.nn.ModuleList()\n",
+    "        input_dims = num_latent_dims\n",
+    "        for i in range(num_hidden_layers):\n",
+    "            self.layers.append(torch.nn.Linear(input_dims, num_hidden_units))\n",
+    "            self.layers.append(torch.nn.ReLU())\n",
+    "            input_dims = num_hidden_units\n",
+    "        self.output = torch.nn.Linear(num_hidden_units, num_latent_dims)\n",
+    "    \n",
+    "    @torch.jit.script_method\n",
+    "    def forward(self, x):\n",
+    "        y = x\n",
+    "        for i, layer in enumerate(self.layers):\n",
+    "            if i == 0:\n",
+    "                y = layer(y)\n",
+    "            else:\n",
+    "                y = y + layer(y)\n",
+    "        return x + self.output(y)\n",
+    "    \n",
+    "    @torch.jit.script_method\n",
+    "    def loss_fn(self, x):\n",
+    "        loss = torch.as_tensor(0.0, device=torch.device(\"cuda\"))\n",
+    "        start = torch.zeros_like(x, device=torch.device(\"cuda\"))\n",
+    "        start[:, :] = x[:, :]\n",
+    "        for i in range(1, 5):\n",
+    "            end = self.forward(start)\n",
+    "            loss += torch.pow(x[i:] - end[:-i], 2).mean()\n",
+    "            start = end\n",
+    "        return loss\n",
+    "    \n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fdd71e28",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mlp = MLP(num_latent_dims=L, num_hidden_units=8, num_hidden_layers=3).to(device)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0ad9dd09",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "list([p.shape for p in mlp.parameters()])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1d25bab1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "train_proj = torch.tensor(svd.transform(train_mat), device=device)\n",
+    "optimizer = torch.optim.Adam(mlp.parameters(), lr=1e-3)\n",
+    "   \n",
+    "loop = tqdm.trange(10_000, ncols=100)\n",
+    "for t in loop:\n",
+    "    loss = mlp.loss_fn(train_proj)\n",
+    "    if t % 100 == 0:\n",
+    "        loop.set_postfix(loss=loss.item())\n",
+    "    loss.backward()\n",
+    "    optimizer.step()\n",
+    "    optimizer.zero_grad()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c625910f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "loop = tqdm.trange(10_000, ncols=100)\n",
+    "for t in loop:\n",
+    "    loss = mlp.loss_fn(train_proj)\n",
+    "    if t % 100 == 0:\n",
+    "        loop.set_postfix(loss=loss.item())\n",
+    "    loss.backward()\n",
+    "    optimizer.step()\n",
+    "    optimizer.zero_grad()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7720e9b6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# rng = np.random.default_rng(seed=321)\n",
+    "# t0s = rng.integers(0, train_mat.shape[0]-30, size=5)\n",
+    "\n",
+    "T = 30\n",
+    "t0 = 1000\n",
+    "x0 = train_mat[t0:t0+1, :]\n",
+    "p0 = svd.transform(x0)\n",
+    "\n",
+    "results = [p0]\n",
+    "for t in range(T):\n",
+    "    x1 = mlp(torch.tensor(results[-1], device=device))\n",
+    "    results.append(x1.detach().cpu().numpy())\n",
+    "pred_trace = np.stack([svd.inverse_transform(r) for r in results], axis=0)\n",
+    "act_trace = train_mat[t0:t0+T+1]\n",
+    "recon_each = svd.inverse_transform(svd.transform(train_mat[t0:t0+T+1, :]))\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "57bd4218",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot_neuron_types = np.sort(np.random.choice(neuron_type_name, 8))\n",
+    "# ['R1', 'R7', 'C2', 'Mi11', 'Tm1', 'Tm4', 'Tm30'] \n",
+    "\n",
+    "_, ax = plt.subplots(len(plot_neuron_types), 1, figsize=(8, 12), sharex=True)\n",
+    "tvals = np.arange(t0, t0+T+1)\n",
+    "rng = np.random.default_rng(seed=123)\n",
+    "picks = [rng.choice(nixs) for nixs in neuron_ixs_by_type]\n",
+    "\n",
+    "for i, ptype in enumerate(plot_neuron_types):\n",
+    "    nix = picks[neuron_type_index[ptype]]\n",
+    "    true_trace = train_mat[t0:t0+T+1, nix]\n",
+    "    ax[i].plot(tvals, true_trace)\n",
+    "    ax[i].set_ylim(true_trace.min()*0.8, true_trace.max()*1.2)\n",
+    "    # time evolve\n",
+    "    ax[i].plot(tvals, pred_trace[:, 0, nix], color=p[-1].get_color(), ls=\"dotted\", label=\"learn linear evolver\")\n",
+    "\n",
+    "    # reconstruct each point using SVD\n",
+    "    ax[i].plot(tvals, recon_each[:, nix], color=p[-1].get_color(), ls=\"dashed\", label=\"reconstruct each time point\")\n",
+    "    ax[i].set_ylabel(ptype)\n",
+    "\n",
+    "plt.subplots_adjust(hspace=0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4f20ae4b",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Notebook that documents a few experiments. 

The data we are modeling consists of simulated flyvis data (fly_N9_54_1). We are modeling the Ca activity matrix that is downsampled 7x. And we drop the initial burn in period.

Observations:
- SVD is very effective at compressing along the neuron dimension. With 256 singular vectors, for example, you can nicely reconstruct neuronal traces.
- Can you use a linear matrix to evolve in latent space and capture the original neuronal dynamics? No.
- What if you used a nonlinear MLP to evolve in latent space? No.
- Whether you use a linear/non-linear function we don't capture real fluctuations in the data. The predicted traces instead are fairly constant and don't fluctuate at all.

TODO:
- [ ] Summarize in [deck](https://docs.google.com/presentation/d/1ULD0v7WBj4BzKdkmteAjRUws9VoXlvv-SRrgfZPmRB4/edit?slide=id.p#slide=id.p)
- [ ] Understand why even though the SVD reconstruction is excellent, it is a terrible representation for learning dynamics. I think it's because vectors `v[t]` and `v[t+1]` are not necessarily much closer than say `v[t]` and `v[t+2]`. We can verify this by computing something like ||v[t]-v[t+1]|| in the original vs latent space. This could explain the above behavior.
