### PR TITLE
Migrate from setup.py to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,10 @@
+[build-system]
+requires = ["setuptools>=45", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "NeuralGraph"
+version = "0.1"
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,0 @@
-from setuptools import setup, find_packages
-
-
-setup(name='NeuralGraph', version='0.1', packages=find_packages(), package_dir={'': 'src'})


### PR DESCRIPTION
Replace legacy setup.py with modern pyproject.toml (PEP 621). This provides a single, standardized configuration file while maintaining the same package structure and functionality.

Changes:
- Add pyproject.toml with build system and project metadata
- Remove setup.py (functionality moved to pyproject.toml)
- Maintain src layout with packages.find configuration
- Verified: pip install -e . works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)