### PR TITLE
feat: relax ruff linting to allow unused variables

### DIFF
--- a/GNN_Main.py
+++ b/GNN_Main.py
@@ -46,7 +46,7 @@ if __name__ == "__main__":
     for config_file_ in config_list:
         print(" ")
         config_root = os.path.dirname(os.path.abspath(__file__)) + "/config"
-        config_file, pre_folder = add_ppppre_folder(config_file_)
+        config_file, pre_folder = add_pre_folder(config_file_)
         config = NeuralGraphConfig.from_yaml(f"{config_root}/{config_file}.yaml")
         config.dataset = pre_folder + config.dataset
         config.config_file = pre_folder + config_file_

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,9 @@ select = [
 ]
 
 # Explicitly ignore all style/quality rules that don't cause runtime errors
-ignore = []
+ignore = [
+    "F841",   # Allow unused local variables (common in research/development code)
+]
 
 [tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["F401", "F403"]  # Allow unused imports and star imports in __init__.py files


### PR DESCRIPTION
- Added F841 to ignored rules to allow unused local variables
- Kept F401 (unused imports) as an error to maintain import hygiene
- This change supports research/development workflows where temporary variables are common during experimentation
- Fixed typo in GNN_Main.py: add_ppppre_folder -> add_pre_folder

Fixes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)